### PR TITLE
remove actions-rs/toolchain@v1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
       - run: rustup component add rustfmt
       - run: rustup component add clippy
 


### PR DESCRIPTION
Rust is included in the github base image now :tada: 